### PR TITLE
Agregando el Login de los Hijos

### DIFF
--- a/app/src/main/java/edu/ucne/doers/data/local/dao/PadreDao.kt
+++ b/app/src/main/java/edu/ucne/doers/data/local/dao/PadreDao.kt
@@ -34,6 +34,16 @@ interface PadreDao {
     )
     suspend fun findEmail(email: String): PadreEntity?
 
+    @Query(
+        """
+            SELECT *
+            FROM Padres
+            WHERE codigoSala =:codigoSala
+            LIMIT 1
+        """
+    )
+    suspend fun findByCodigoSala(codigoSala: String): PadreEntity?
+
     @Delete
     suspend fun delete(padreEntity: PadreEntity)
 

--- a/app/src/main/java/edu/ucne/doers/data/repository/HijoRepository.kt
+++ b/app/src/main/java/edu/ucne/doers/data/repository/HijoRepository.kt
@@ -1,12 +1,15 @@
 package edu.ucne.doers.data.repository
 
 import edu.ucne.doers.data.local.dao.HijoDao
+import edu.ucne.doers.data.local.dao.PadreDao
 import edu.ucne.doers.data.local.entity.HijoEntity
+import edu.ucne.doers.data.remote.Resource
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class HijoRepository @Inject constructor(
-    private val hijoDao: HijoDao
+    private val hijoDao: HijoDao,
+    private val padreDao: PadreDao
 ) {
     suspend fun save(hijo: HijoEntity) = hijoDao.save(hijo)
 
@@ -15,4 +18,15 @@ class HijoRepository @Inject constructor(
     fun getAll(): Flow<List<HijoEntity>> = hijoDao.getAll()
 
     suspend fun delete(hijo: HijoEntity) = hijoDao.delete(hijo)
+
+    suspend fun loginHijo(nombre: String, codigoSala: String): Resource<Boolean> {
+        val padre = padreDao.findByCodigoSala(codigoSala)
+        return if (padre != null) {
+            val hijo = HijoEntity(padreId = padre.padreId, nombre = nombre)
+            hijoDao.save(hijo)
+            Resource.Success(true)
+        } else {
+            Resource.Error("El código de sala no existe")
+        }
+    }
 }

--- a/app/src/main/java/edu/ucne/doers/presentation/hijos/HijoLoginScreen.kt
+++ b/app/src/main/java/edu/ucne/doers/presentation/hijos/HijoLoginScreen.kt
@@ -1,0 +1,119 @@
+package edu.ucne.doers.presentation.hijos
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChildCare
+import androidx.compose.material3.*
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun HijoLoginScreen(
+    onChildLoggedIn: () -> Unit,
+    viewModel: HijoViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    var childName by remember { mutableStateOf("") }
+    var roomCode by remember { mutableStateOf("") }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    LaunchedEffect(uiState.signInError) {
+        uiState.signInError?.let { errorMsg ->
+            snackbarHostState.showSnackbar(errorMsg)
+        }
+    }
+
+    LaunchedEffect(uiState.isSignInSuccessful) {
+        if (uiState.isSignInSuccessful) {
+            onChildLoggedIn()
+        }
+    }
+
+    if (uiState.isLoading) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    } else {
+        Scaffold(
+            containerColor = Color(0xFFF0F2F5)
+        ) { innerPadding ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = "¡Bienvenido a Doers!",
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF0D47A1)
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Icon(
+                        imageVector = Icons.Filled.ChildCare,
+                        contentDescription = "Icono de Niño",
+                        modifier = Modifier.size(100.dp),
+                        tint = Color(0xFF42A5F5)
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                    OutlinedTextField(
+                        value = childName,
+                        onValueChange = { childName = it },
+                        label = { Text("Tu nombre") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    OutlinedTextField(
+                        value = roomCode,
+                        onValueChange = { roomCode = it },
+                        label = { Text("Código de la sala") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                    Button(
+                        onClick = { viewModel.loginChild(childName, roomCode) },
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = !uiState.isLoading,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFF4CAF50)
+                        )
+                    ) {
+                        if (uiState.isLoading) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                color = Color.White
+                            )
+                        } else {
+                            Text("Unirse a la sala", fontSize = 20.sp)
+                        }
+                    }
+                }
+
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                    modifier = Modifier.align(Alignment.BottomCenter)
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/edu/ucne/doers/presentation/hijos/HijoLoginScreen.kt
+++ b/app/src/main/java/edu/ucne/doers/presentation/hijos/HijoLoginScreen.kt
@@ -96,6 +96,7 @@ fun HijoLoginScreen(
                         colors = ButtonDefaults.buttonColors(
                             containerColor = Color(0xFF4CAF50)
                         )
+
                     ) {
                         if (uiState.isLoading) {
                             CircularProgressIndicator(

--- a/app/src/main/java/edu/ucne/doers/presentation/hijos/HijoUiState.kt
+++ b/app/src/main/java/edu/ucne/doers/presentation/hijos/HijoUiState.kt
@@ -1,0 +1,15 @@
+package edu.ucne.doers.presentation.hijos
+
+import edu.ucne.doers.data.local.entity.HijoEntity
+
+data class HijoUiState(
+    val hijoId: Int? = null,
+    val nombre: String? = "",
+    val codigoSala: String? = "",
+    val hijos: List<HijoEntity> = emptyList(),
+    val isSuccess: Boolean = false,
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isSignInSuccessful: Boolean = false,
+    val signInError: String? = null
+)

--- a/app/src/main/java/edu/ucne/doers/presentation/hijos/HijoViewModel.kt
+++ b/app/src/main/java/edu/ucne/doers/presentation/hijos/HijoViewModel.kt
@@ -1,0 +1,54 @@
+package edu.ucne.doers.presentation.hijos
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import edu.ucne.doers.data.remote.Resource
+import edu.ucne.doers.data.repository.HijoRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HijoViewModel @Inject constructor(
+    private val hijoRepository: HijoRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HijoUiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun loginChild(nombre: String, codigoSala: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, signInError = null) }
+            when (val resource = hijoRepository.loginHijo(nombre, codigoSala)) {
+                is Resource.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isSuccess = true,
+                            isSignInSuccessful = true,
+                            nombre = nombre,
+                            codigoSala = codigoSala,
+                            isLoading = false,
+                            signInError = null
+                        )
+                    }
+                }
+                is Resource.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isSuccess = false,
+                            isSignInSuccessful = false,
+                            isLoading = false,
+                            signInError = resource.message
+                        )
+                    }
+                }
+                is Resource.Loading -> {
+                    _uiState.update { it.copy(isLoading = true) }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/edu/ucne/doers/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/edu/ucne/doers/presentation/home/HomeScreen.kt
@@ -36,6 +36,7 @@ import edu.ucne.doers.R
 @Composable
 fun HomeScreen(
     onSignClickWithGoogle: () -> Unit,
+    onHijoClick: () -> Unit,
     isLoading: Boolean = false,
     errorMessage: String? = null,
 ) {
@@ -109,7 +110,7 @@ fun HomeScreen(
                 }
 
                 Button(
-                    onClick = { },
+                    onClick = onHijoClick,
                     modifier = Modifier
                         .size(140.dp)
                         .clip(CircleShape)

--- a/app/src/main/java/edu/ucne/doers/presentation/navigation/RegistroNavHost.kt
+++ b/app/src/main/java/edu/ucne/doers/presentation/navigation/RegistroNavHost.kt
@@ -19,6 +19,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import edu.ucne.doers.presentation.hijos.HijoLoginScreen
 import edu.ucne.doers.presentation.home.HomeScreen
 import edu.ucne.doers.presentation.padres.PadreScreen
 import edu.ucne.doers.presentation.padres.PadreViewModel
@@ -119,6 +120,9 @@ fun DoersNavHost(
                                 }
                             }
                         }
+                    },
+                    onHijoClick = {
+                        navHostController.navigate(Screen.HijoLogin)
                     }
                 )
             }
@@ -127,6 +131,16 @@ fun DoersNavHost(
                 PadreScreen(
                     viewModel = viewModel,
                     navController = navHostController,
+                )
+            }
+
+            composable<Screen.HijoLogin> {
+                HijoLoginScreen(
+                    onChildLoggedIn = {
+                        navHostController.navigate("child_home") {
+                            popUpTo(Screen.Home) { inclusive = true }
+                        }
+                    }
                 )
             }
 

--- a/app/src/main/java/edu/ucne/doers/presentation/navigation/Screen.kt
+++ b/app/src/main/java/edu/ucne/doers/presentation/navigation/Screen.kt
@@ -15,4 +15,6 @@ sealed class Screen {
     data object TareasList : Screen()
     @Serializable
     data class  Tarea(val tareaId: Int) : Screen()
+    @Serializable
+    data object HijoLogin : Screen()
 }


### PR DESCRIPTION
- Se agregó la pantalla de login para hijos (HijoLoginScreen):

- Se creó el ViewModel para el login de hijos (HijoViewModel):

- Se definió un HijoUiState similar al PadreUiState para gestionar los estados (isLoading, isSignInSuccessful, signInError, etc.).

- Se implementó la lógica para validar el código de sala mediante el repositorio y actualizar el estado en consecuencia.

- En HijoRepository, se agregó la función loginHijo que valida el código de sala (buscando en PadreDao) y, en caso de éxito, guarda un nuevo registro de HijoEntity.

- Se verificó que PadreDao cuente con el método findByCodigoSala para permitir la validación del código.

- Se actualizó la navegación: